### PR TITLE
Added .lowercased() to forPolicy in getUserByPolicy method

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "AzureAD/microsoft-authentication-library-for-objc" "8e87860b09148198b756c821909b0fe5fe2c1da6"
+github "AzureAD/microsoft-authentication-library-for-objc" "32582453d17e156882b8ad5d8d50d319b14513c3"

--- a/MSALiOSB2C/ViewController.swift
+++ b/MSALiOSB2C/ViewController.swift
@@ -366,7 +366,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
     func getUserByPolicy (withUsers: [MSALUser], forPolicy: String) throws -> MSALUser? {
         
         for user in withUsers {
-            if (user.userIdentifier().components(separatedBy: ".")[0].hasSuffix(forPolicy)) {
+            if (user.userIdentifier().components(separatedBy: ".")[0].hasSuffix(forPolicy.lowercased())) {
                 return user
             }
     }


### PR DESCRIPTION
I had an issue with the sample where the refresh token call was not finding any users while all the other functions worked fine. I did some digging and found that the user identifier is returned in all lowercase (8fd56ab5-06a9-3c23-9717-4ae5d86f967c-b2c_1_policy1) despite my policy name having capital letters in it (B2C_1_Policy1).  Changing the forPolicy variable to all lowercase fixed the issue and returned a user and refresh token.