### PR TITLE
Upgraded to Swift 4.0

### DIFF
--- a/MSALiOSB2C.xcodeproj/project.pbxproj
+++ b/MSALiOSB2C.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.identity.client.sample.MSALiOSB2C;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -461,7 +461,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.identity.client.sample.MSALiOSB2C;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Swift 3.0 is not supported by Xcode 10.2. No code changes required.