### PR TITLE
Replace login.microsoftonline.com w/b2clogin.com

### DIFF
--- a/MSALiOSB2C/ViewController.swift
+++ b/MSALiOSB2C/ViewController.swift
@@ -69,9 +69,12 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
             
             let authority = try self.getAuthority(forPolicy: self.kSignupOrSigninPolicy)
             
+            let b2cAuthority = try MSALB2CAuthority(url: authority)
+
             // Provide configuration for MSALPublicClientApplication
             // MSAL will use default redirect uri when you provide nil
-            let pcaConfig = MSALPublicClientApplicationConfig(clientId: kClientID, redirectUri: nil, authority: authority)
+            let pcaConfig = MSALPublicClientApplicationConfig(clientId: kClientID, redirectUri: nil, authority: b2cAuthority)
+            pcaConfig.knownAuthorities = b2cAuthority
             self.application = try MSALPublicClientApplication(configuration: pcaConfig)
         } catch {
             self.updateLoggingText(text: "Unable to create application \(error)")

--- a/MSALiOSB2C/ViewController.swift
+++ b/MSALiOSB2C/ViewController.swift
@@ -67,14 +67,13 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
              The scheme part, i.e. "msal<your-client-id-here>", needs to be registered in the info.plist of the project
              */
             
-            let authority = try self.getAuthority(forPolicy: self.kSignupOrSigninPolicy)
-            
-            let b2cAuthority = try MSALB2CAuthority(url: authority)
+            let siginPolicyAuthority = try self.getAuthority(forPolicy: self.kSignupOrSigninPolicy)
+            let editProfileAuthority = try self.getAuthority(forPolicy: self.kEditProfilePolicy)
 
             // Provide configuration for MSALPublicClientApplication
             // MSAL will use default redirect uri when you provide nil
-            let pcaConfig = MSALPublicClientApplicationConfig(clientId: kClientID, redirectUri: nil, authority: b2cAuthority)
-            pcaConfig.knownAuthorities = b2cAuthority
+            let pcaConfig = MSALPublicClientApplicationConfig(clientId: kClientID, redirectUri: nil, authority: siginPolicyAuthority)
+            pcaConfig.knownAuthorities = [siginPolicyAuthority, editProfileAuthority]
             self.application = try MSALPublicClientApplication(configuration: pcaConfig)
         } catch {
             self.updateLoggingText(text: "Unable to create application \(error)")

--- a/MSALiOSB2C/ViewController.swift
+++ b/MSALiOSB2C/ViewController.swift
@@ -34,6 +34,7 @@ import MSAL
 class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate  {
     
     let kTenantName = "fabrikamb2c.onmicrosoft.com" // Your tenant name
+    let kAuthorityHostName = "fabrikamb2c.b2clogin.com" // Your authority host name
     let kClientID = "90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6" // Your client ID from the portal when you created your application
     let kSignupOrSigninPolicy = "b2c_1_susi" // Your signup and sign-in policy you created in the portal
     let kEditProfilePolicy = "b2c_1_edit_profile" // Your edit policy you created in the portal
@@ -42,7 +43,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
     let kScopes: [String] = ["https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read"] // This is a scope that you've configured your backend API to look for.
     
     // DO NOT CHANGE - This is the format of OIDC Token and Authorization endpoints for Azure AD B2C.
-    let kEndpoint = "https://login.microsoftonline.com/tfp/%@/%@"
+    let kEndpoint = "https://%@/tfp/%@/%@"
     
     var application: MSALPublicClientApplication!
     
@@ -364,7 +365,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
      use for the current user flow.
      */
     func getAuthority(forPolicy policy: String) throws -> MSALB2CAuthority {
-        guard let authorityURL = URL(string: String(format: self.kEndpoint, self.kTenantName, policy)) else {
+        guard let authorityURL = URL(string: String(format: self.kEndpoint, self.kAuthorityHostName, self.kTenantName, policy)) else {
             throw NSError(domain: "SomeDomain",
                           code: 1,
                           userInfo: ["errorDescription": "Unable to create authority URL!"])


### PR DESCRIPTION
This is the correct endpoint for the tenant using b2c: https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi/v2.0/.well-known/openid-configuration
Not sure if the fixed I did are correct, or if there are tests, but i think something like this should unblock the customers reporting issues w/this sample.
cc: @jmprieur @oldalton