### PR TITLE
Change dependency manager from Carthage to Cocoapods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,13 +43,7 @@ playground.xcworkspace
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
-# Pods/
-
-# Carthage
-#
-# Add this line if you want to avoid checking in source code from Carthage dependencies.
-Carthage/Checkouts
-Carthage/Build
+Pods/
 
 # fastlane
 #
@@ -63,6 +57,5 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 
-Carthage/
 
 \.DS_Store

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "AzureAD/microsoft-authentication-library-for-objc" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "AzureAD/microsoft-authentication-library-for-objc" "c0aaed2a1763907a9b1fca6fc8aa5c2995a07bd3"

--- a/MSALiOSB2C.xcodeproj/project.pbxproj
+++ b/MSALiOSB2C.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		41C6CB0C8B4960084421C789 /* Pods_MSALiOSB2C.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9342F700D2B4746D5CEEA6 /* Pods_MSALiOSB2C.framework */; };
+		942B869215457C62F0DDC249 /* Pods_MSALiOSB2C_MSALiOSB2CUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0500F53C0CA552BB0F226F4 /* Pods_MSALiOSB2C_MSALiOSB2CUITests.framework */; };
+		C937AD4C62B6258342A142A4 /* Pods_MSALiOSB2CTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51A603AFEDEE86C7BB178DF5 /* Pods_MSALiOSB2CTests.framework */; };
 		FB2510581EBBE8030044F3F7 /* MSAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB2510571EBBE8030044F3F7 /* MSAL.framework */; };
 		FB7630D11EB7EF8700D2A969 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7630D01EB7EF8700D2A969 /* AppDelegate.swift */; };
 		FB7630D31EB7EF8700D2A969 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7630D21EB7EF8700D2A969 /* ViewController.swift */; };
@@ -33,6 +36,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		146F3234213D2738F8B8D91B /* Pods-MSALiOSB2CTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MSALiOSB2CTests.debug.xcconfig"; path = "Target Support Files/Pods-MSALiOSB2CTests/Pods-MSALiOSB2CTests.debug.xcconfig"; sourceTree = "<group>"; };
+		1D37610600308654FAD8960F /* Pods-MSALiOSB2C-MSALiOSB2CUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MSALiOSB2C-MSALiOSB2CUITests.release.xcconfig"; path = "Target Support Files/Pods-MSALiOSB2C-MSALiOSB2CUITests/Pods-MSALiOSB2C-MSALiOSB2CUITests.release.xcconfig"; sourceTree = "<group>"; };
+		2C8F0FF4F115A238BE411186 /* Pods-MSALiOSB2C.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MSALiOSB2C.release.xcconfig"; path = "Target Support Files/Pods-MSALiOSB2C/Pods-MSALiOSB2C.release.xcconfig"; sourceTree = "<group>"; };
+		3FB17B5AA3366F90EF1E5FF9 /* Pods-MSALiOSB2C.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MSALiOSB2C.debug.xcconfig"; path = "Target Support Files/Pods-MSALiOSB2C/Pods-MSALiOSB2C.debug.xcconfig"; sourceTree = "<group>"; };
+		51A603AFEDEE86C7BB178DF5 /* Pods_MSALiOSB2CTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MSALiOSB2CTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6A70C9DB2C38528B0196142E /* Pods-MSALiOSB2C-MSALiOSB2CUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MSALiOSB2C-MSALiOSB2CUITests.debug.xcconfig"; path = "Target Support Files/Pods-MSALiOSB2C-MSALiOSB2CUITests/Pods-MSALiOSB2C-MSALiOSB2CUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		8A2168D20B2BC4D080A49E53 /* Pods-MSALiOSB2CTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MSALiOSB2CTests.release.xcconfig"; path = "Target Support Files/Pods-MSALiOSB2CTests/Pods-MSALiOSB2CTests.release.xcconfig"; sourceTree = "<group>"; };
+		9E9342F700D2B4746D5CEEA6 /* Pods_MSALiOSB2C.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MSALiOSB2C.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D0500F53C0CA552BB0F226F4 /* Pods_MSALiOSB2C_MSALiOSB2CUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MSALiOSB2C_MSALiOSB2CUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB2510571EBBE8030044F3F7 /* MSAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MSAL.framework; path = Carthage/Build/iOS/MSAL.framework; sourceTree = "<group>"; };
 		FB7368BE1EB94C8100FB407E /* MSALiOSB2C.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = MSALiOSB2C.xcodeproj; sourceTree = "<group>"; };
 		FB7630CD1EB7EF8700D2A969 /* MSALiOSB2C.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MSALiOSB2C.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -53,6 +65,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FB2510581EBBE8030044F3F7 /* MSAL.framework in Frameworks */,
+				41C6CB0C8B4960084421C789 /* Pods_MSALiOSB2C.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -60,6 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C937AD4C62B6258342A142A4 /* Pods_MSALiOSB2CTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,14 +81,31 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				942B869215457C62F0DDC249 /* Pods_MSALiOSB2C_MSALiOSB2CUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D6CE424223CC460CA457D3D4 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				3FB17B5AA3366F90EF1E5FF9 /* Pods-MSALiOSB2C.debug.xcconfig */,
+				2C8F0FF4F115A238BE411186 /* Pods-MSALiOSB2C.release.xcconfig */,
+				6A70C9DB2C38528B0196142E /* Pods-MSALiOSB2C-MSALiOSB2CUITests.debug.xcconfig */,
+				1D37610600308654FAD8960F /* Pods-MSALiOSB2C-MSALiOSB2CUITests.release.xcconfig */,
+				146F3234213D2738F8B8D91B /* Pods-MSALiOSB2CTests.debug.xcconfig */,
+				8A2168D20B2BC4D080A49E53 /* Pods-MSALiOSB2CTests.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		FB25105E1EBCF9320044F3F7 /* Products */ = {
 			isa = PBXGroup;
+			children = (
+			);
 			name = Products;
 			sourceTree = "<group>";
 		};
@@ -85,6 +116,7 @@
 				FB7630CF1EB7EF8700D2A969 /* MSALiOSB2C */,
 				FB7630CE1EB7EF8700D2A969 /* Products */,
 				FB7630FE1EB7EFDA00D2A969 /* Frameworks */,
+				D6CE424223CC460CA457D3D4 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -116,6 +148,9 @@
 			isa = PBXGroup;
 			children = (
 				FB2510571EBBE8030044F3F7 /* MSAL.framework */,
+				9E9342F700D2B4746D5CEEA6 /* Pods_MSALiOSB2C.framework */,
+				D0500F53C0CA552BB0F226F4 /* Pods_MSALiOSB2C_MSALiOSB2CUITests.framework */,
+				51A603AFEDEE86C7BB178DF5 /* Pods_MSALiOSB2CTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -127,10 +162,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FB7630F51EB7EF8700D2A969 /* Build configuration list for PBXNativeTarget "MSALiOSB2C" */;
 			buildPhases = (
+				2841944EAE5B35BAA4A4FD2F /* [CP] Check Pods Manifest.lock */,
 				FB7630C91EB7EF8700D2A969 /* Sources */,
 				FB7630CA1EB7EF8700D2A969 /* Frameworks */,
 				FB7630CB1EB7EF8700D2A969 /* Resources */,
-				FB2510591EBBE8180044F3F7 /* ShellScript */,
+				685D37BEF83BC58F5B3D6C65 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,6 +181,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FB7630F81EB7EF8700D2A969 /* Build configuration list for PBXNativeTarget "MSALiOSB2CTests" */;
 			buildPhases = (
+				EA3A9A3F80476B65A17D752F /* [CP] Check Pods Manifest.lock */,
 				FB7630DD1EB7EF8700D2A969 /* Sources */,
 				FB7630DE1EB7EF8700D2A969 /* Frameworks */,
 				FB7630DF1EB7EF8700D2A969 /* Resources */,
@@ -163,9 +200,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FB7630FB1EB7EF8700D2A969 /* Build configuration list for PBXNativeTarget "MSALiOSB2CUITests" */;
 			buildPhases = (
+				828AB71AB42DC764EDBFCB06 /* [CP] Check Pods Manifest.lock */,
 				FB7630E81EB7EF8700D2A969 /* Sources */,
 				FB7630E91EB7EF8700D2A969 /* Frameworks */,
 				FB7630EA1EB7EF8700D2A969 /* Resources */,
+				89E539BDEA9CD350112A0EE0 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -216,6 +255,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -265,19 +305,107 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		FB2510591EBBE8180044F3F7 /* ShellScript */ = {
+		2841944EAE5B35BAA4A4FD2F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MSALiOSB2C-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		685D37BEF83BC58F5B3D6C65 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/MSAL.framework",
+				"${PODS_ROOT}/Target Support Files/Pods-MSALiOSB2C/Pods-MSALiOSB2C-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/MSAL/MSAL.framework",
 			);
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MSAL.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MSALiOSB2C/Pods-MSALiOSB2C-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		828AB71AB42DC764EDBFCB06 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MSALiOSB2C-MSALiOSB2CUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		89E539BDEA9CD350112A0EE0 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MSALiOSB2C-MSALiOSB2CUITests/Pods-MSALiOSB2C-MSALiOSB2CUITests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/MSAL/MSAL.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MSAL.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MSALiOSB2C-MSALiOSB2CUITests/Pods-MSALiOSB2C-MSALiOSB2CUITests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EA3A9A3F80476B65A17D752F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-MSALiOSB2CTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -437,11 +565,12 @@
 		};
 		FB7630F61EB7EF8700D2A969 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3FB17B5AA3366F90EF1E5FF9 /* Pods-MSALiOSB2C.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = MSALiOSB2C/MSALiOSB2C.entitlements;
 				DEVELOPMENT_TEAM = UBF8T346G9;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = MSALiOSB2C/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.identity.client.sample.MSALiOSB2C;
@@ -452,11 +581,12 @@
 		};
 		FB7630F71EB7EF8700D2A969 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2C8F0FF4F115A238BE411186 /* Pods-MSALiOSB2C.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = MSALiOSB2C/MSALiOSB2C.entitlements;
 				DEVELOPMENT_TEAM = UBF8T346G9;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = MSALiOSB2C/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.identity.client.sample.MSALiOSB2C;
@@ -467,6 +597,7 @@
 		};
 		FB7630F91EB7EF8700D2A969 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 146F3234213D2738F8B8D91B /* Pods-MSALiOSB2CTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -482,6 +613,7 @@
 		};
 		FB7630FA1EB7EF8700D2A969 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8A2168D20B2BC4D080A49E53 /* Pods-MSALiOSB2CTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -497,6 +629,7 @@
 		};
 		FB7630FC1EB7EF8700D2A969 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6A70C9DB2C38528B0196142E /* Pods-MSALiOSB2C-MSALiOSB2CUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = UBF8T346G9;
@@ -511,6 +644,7 @@
 		};
 		FB7630FD1EB7EF8700D2A969 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1D37610600308654FAD8960F /* Pods-MSALiOSB2C-MSALiOSB2CUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = UBF8T346G9;

--- a/MSALiOSB2C.xcworkspace/contents.xcworkspacedata
+++ b/MSALiOSB2C.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:MSALiOSB2C.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/MSALiOSB2C.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MSALiOSB2C.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MSALiOSB2C/ViewController.swift
+++ b/MSALiOSB2C/ViewController.swift
@@ -111,7 +111,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
              flow completes, or encounters an error.
              */
             
-            let webViewParameters = MSALWebviewParameters(parentViewController: self)
+            let webViewParameters = MSALWebviewParameters(authPresentationViewController: self)
             let parameters = MSALInteractiveTokenParameters(scopes: kScopes, webviewParameters: webViewParameters)
             parameters.promptType = .selectAccount
             parameters.authority = authority
@@ -161,7 +161,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
              */
             
             let thisAccount = try self.getAccountByPolicy(withAccounts: application.allAccounts(), policy: kEditProfilePolicy)
-            let webViewParameters = MSALWebviewParameters(parentViewController: self)
+            let webViewParameters = MSALWebviewParameters(authPresentationViewController: self)
             let parameters = MSALInteractiveTokenParameters(scopes: kScopes, webviewParameters: webViewParameters)
             parameters.authority = authority
             parameters.account = thisAccount
@@ -230,7 +230,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
                             // Notice we supply the account here. This ensures we acquire token for the same account
                             // as we originally authenticated.
                             
-                            let webviewParameters = MSALWebviewParameters(parentViewController: self)
+                            let webviewParameters = MSALWebviewParameters(authPresentationViewController: self)
                             let parameters = MSALInteractiveTokenParameters(scopes: self.kScopes, webviewParameters: webviewParameters)
                             parameters.account = thisAccount
                             

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,17 @@
+use_frameworks!
+
+platform :ios, '11.0'
+ 
+target 'MSALiOSB2C' do
+  pod 'MSAL'
+
+  target 'MSALiOSB2CTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+
+  target 'MSALiOSB2CUITests' do
+    # Pods for testing
+  end
+
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - MSAL (1.1.13):
-    - MSAL/app-lib (= 1.1.13)
-  - MSAL/app-lib (1.1.13)
+  - MSAL (1.1.18):
+    - MSAL/app-lib (= 1.1.18)
+  - MSAL/app-lib (1.1.18)
 
 DEPENDENCIES:
   - MSAL
@@ -11,7 +11,7 @@ SPEC REPOS:
     - MSAL
 
 SPEC CHECKSUMS:
-  MSAL: 291d1cfc8d095a6bfe669e4beda2c5be6774a4ff
+  MSAL: 048eea7160a7b8960a2359ac9135e098ec58ad34
 
 PODFILE CHECKSUM: a752ddf8f698358c8de41285e54376f7152adc6d
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - MSAL (1.1.18):
-    - MSAL/app-lib (= 1.1.18)
-  - MSAL/app-lib (1.1.18)
+  - MSAL (1.1.22):
+    - MSAL/app-lib (= 1.1.22)
+  - MSAL/app-lib (1.1.22)
 
 DEPENDENCIES:
   - MSAL

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,18 @@
+PODS:
+  - MSAL (1.1.13):
+    - MSAL/app-lib (= 1.1.13)
+  - MSAL/app-lib (1.1.13)
+
+DEPENDENCIES:
+  - MSAL
+
+SPEC REPOS:
+  trunk:
+    - MSAL
+
+SPEC CHECKSUMS:
+  MSAL: 291d1cfc8d095a6bfe669e4beda2c5be6774a4ff
+
+PODFILE CHECKSUM: a752ddf8f698358c8de41285e54376f7152adc6d
+
+COCOAPODS: 1.9.3

--- a/README.md
+++ b/README.md
@@ -93,12 +93,14 @@ $ open MSALiOSB2C.xcworkspace
 In the `ViewControler.swift` file, update the variables at the top of this file with the information for your tenant.
 
 ```swift
-    let kTenantName = "<tenant>.onmicrosoft.com" // Your tenant name
-    let kClientID = "<your-client-id>" // Your client ID from the portal when you created your application
-    let kSignupOrSigninPolicy = "<your-signin-policy>" // Your signup and sign-in policy you created in the portal
-    let kEditProfilePolicy = "<your-edit-profile-policy>" // Your edit policy you created in the portal
-    let kGraphURI = "<Your backend API>" // This is your backend API that you've configured to accept your app's tokens
-    let kScopes: [String] = ["<Your backend API>/demo.read"] // This is a scope that you've configured your backend API to look for.
+    let kTenantName = "fabrikamb2c.onmicrosoft.com" // Your tenant name
+    let kAuthorityHostName = "fabrikamb2c.b2clogin.com" // Your authority host name
+    let kClientID = "90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6" // Your client ID from the portal when you created your application
+    let kSignupOrSigninPolicy = "b2c_1_susi" // Your signup and sign-in policy you created in the portal
+    let kEditProfilePolicy = "b2c_1_edit_profile" // Your edit policy you created in the portal
+    let kResetPasswordPolicy = "b2c_1_reset" // Your reset password policy you created in the portal
+    let kGraphURI = "https://fabrikamb2chello.azurewebsites.net/hello" // This is your backend API that you've configured to accept your app's tokens
+    let kScopes: [String] = ["https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read"] // This is a scope that you've configured your backend API to look for.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ From terminal navigate to the directory where the podfile is located
 ```
 $ pod install
 ...
-$ open MSALiOS.xcworkspace
+$ open MSALiOSB2C.xcworkspace
 ```
 
 ## Configure your application

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ do {
 	let application = try MSALPublicClientApplication(configuration: pcaConfig)
             
 	let viewController = self /*replace with your main presentation controller here */
-	let webViewParameters = MSALWebviewParameters(parentViewController: viewController)
+	let webViewParameters = MSALWebviewParameters(authPresentationViewController: viewController)
 	let interactiveParameters = MSALInteractiveTokenParameters(scopes: ["<enter-your-scope-here>"], webviewParameters: webViewParameters)
             
 	application.acquireToken(with: interactiveParameters) { (result, error) in
@@ -59,30 +59,15 @@ You will need to have a B2C client application registered with Microsoft. Follow
 
 ## Installation
 
-We use [Carthage](https://github.com/Carthage/Carthage) for package management during the preview period of MSAL. This package manager integrates very nicely with XCode while maintaining our ability to make changes to the library. The sample is set up to use Carthage.
+Load the podfile using cocoapods. This will create a new XCode Workspace you will load.
 
-##### If you're building for iOS, tvOS, or watchOS
+From terminal navigate to the directory where the podfile is located
 
-1. Install Carthage on your Mac using a download from their website or if using Homebrew `brew install carthage`.
-1. We have already created a `Cartfile` that lists the MSAL library for this project on Github. We use the `/dev` branch.
-1. Run `carthage bootstrap --platform iOS`. This will fetch dependencies into a `Carthage/Checkouts` folder, then build the MSAL library.
-1. On your application targets’ “General” settings tab, in the “Linked Frameworks and Libraries” section, drag and drop the `MSAL.framework` from the `Carthage/Build` folder on disk.
-1. On your application targets’ “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase”. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
-
-  ```sh
-  /usr/local/bin/carthage copy-frameworks
-  ```
-
-  and add the paths to the frameworks you want to use under “Input Files”, e.g.:
-
-  ```
-  $(SRCROOT)/Carthage/Build/iOS/MSAL.framework
-  ```
-  This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries and ensures that necessary bitcode-related files and dSYMs are copied when archiving.
-
-With the debug information copied into the built products directory, Xcode will be able to symbolicate the stack trace whenever you stop at a breakpoint. This will also enable you to step through third-party code in the debugger.
-
-When archiving your application for submission to the App Store or TestFlight, Xcode will also copy these files into the dSYMs subdirectory of your application’s `.xcarchive` bundle.
+```
+$ pod install
+...
+$ open MSALiOS.xcworkspace
+```
 
 ## Configure your application
 


### PR DESCRIPTION
The main focus of this PR is to change the dependency manager that installs MSAL in the iOS B2C sample from Carthage to Cocoapods. Carthage has been reported to not work very well on some people's machines, plus Cocoapods is used in other MSAL iOS samples as well, so this can keep the MSAL installation steps the same across code samples.

This PR also addresses a few instances of deprecated MSALWebviewParameters `initWithParentViewController` instances, as well as address a few references to that deprecated method in the ReadMe.